### PR TITLE
Feature/update scan

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -43,11 +43,19 @@ CREATE TABLE IF NOT EXISTS full_scan_summaries (
     timestamp TEXT NOT NULL,
     analysis_mode TEXT NOT NULL,
     user_consent TEXT NOT NULL,
-    zip_hash TEXT,
     project_summaries_json TEXT NOT NULL
 )
 """
 
+# Table to store file hashes for deduplication (One-to-Many relationship)
+CREATE_SCAN_HASHES_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS scan_hashes (
+    hash_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    summary_id INTEGER NOT NULL,
+    file_hash TEXT NOT NULL,
+    FOREIGN KEY(summary_id) REFERENCES full_scan_summaries(summary_id)
+)
+"""
 
 # ----------------------
 # Initialization
@@ -62,12 +70,7 @@ def ensure_db_initialized(conn: sqlite3.Connection) -> None:
     conn.execute(USER_CONFIG_TABLE_SQL)
     # Ensure the table for full scans exists.
     conn.execute(CREATE_FULL_SCAN_TABLE_SQL)
-    
-    # Migration: Add zip_hash column if it doesn't exist (for existing DBs)
-    try:
-        conn.execute("ALTER TABLE full_scan_summaries ADD COLUMN zip_hash TEXT")
-    except sqlite3.OperationalError:
-        pass  # Column likely already exists
+    conn.execute(CREATE_SCAN_HASHES_TABLE_SQL)
 
 # ----------------------
 # Save results
@@ -126,26 +129,69 @@ def save_full_scan(
         "contributor_profiles": analysis_results.get("contributor_profiles", {}),
         "analysis_mode": analysis_mode,
         "user_consent": "Yes" if user_consent else "No",
+        "source_hashes": [analysis_results.get("zip_hash")] if analysis_results.get("zip_hash") else [],
         "timestamp": datetime.now().isoformat()
     }
     
-    zip_hash = analysis_results.get("zip_hash")
-
     with sqlite3.connect(db_path) as conn:
         ensure_db_initialized(conn)
-        conn.execute(
+        cursor = conn.execute(
             """
-            INSERT INTO full_scan_summaries (timestamp, analysis_mode, user_consent, zip_hash, project_summaries_json)
-            VALUES (?, ?, ?, ?, ?)
+            INSERT INTO full_scan_summaries (timestamp, analysis_mode, user_consent, project_summaries_json)
+            VALUES (?, ?, ?, ?)
             """,
             (
                 full_scan_data["timestamp"],
                 analysis_mode,
                 full_scan_data["user_consent"],
-                zip_hash,
                 json.dumps(full_scan_data, ensure_ascii=False, default=str),
             )
         )
+        summary_id = cursor.lastrowid
+
+        # Save hashes to the lookup table for fast deduplication
+        hashes = full_scan_data.get("source_hashes", [])
+        if hashes:
+            conn.executemany(
+                "INSERT INTO scan_hashes (summary_id, file_hash) VALUES (?, ?)",
+                [(summary_id, h) for h in hashes]
+            )
+        conn.commit()
+
+def update_full_scan(summary_id, merged_data, db_path=DB_NAME):
+    """
+    Updates the JSON data for an existing scan record.
+    Used when adding incremental information to a portfolio.
+    """
+    # Helper to serialize datetimes (similar to save_full_scan)
+    def _serialize_project(p): 
+        p_copy = p.copy()
+        for key in ["first_modified", "last_modified"]:
+            if key in p_copy and isinstance(p_copy[key], datetime):
+                p_copy[key] = p_copy[key].isoformat()
+        return p_copy
+
+    if "project_summaries" in merged_data:
+        merged_data["project_summaries"] = [
+            _serialize_project(p) for p in merged_data["project_summaries"]
+        ]
+
+    with sqlite3.connect(db_path) as conn:
+        ensure_db_initialized(conn)
+        conn.execute(
+            "UPDATE full_scan_summaries SET project_summaries_json = ? WHERE summary_id = ?",
+            (json.dumps(merged_data, ensure_ascii=False, default=str), summary_id)
+        )
+        
+        # Update hashes table: Remove old entries and re-insert the current list
+        conn.execute("DELETE FROM scan_hashes WHERE summary_id = ?", (summary_id,))
+        
+        hashes = merged_data.get("source_hashes", [])
+        if hashes:
+            conn.executemany(
+                "INSERT INTO scan_hashes (summary_id, file_hash) VALUES (?, ?)",
+                [(summary_id, h) for h in hashes]
+            )
         conn.commit()
 
 def get_full_scan_by_id(summary_id, db_path=DB_NAME):
@@ -178,6 +224,7 @@ def delete_full_scan_by_id(summary_id, db_path=DB_NAME):
     with sqlite3.connect(db_path) as conn:
         ensure_db_initialized(conn)
         cursor = conn.execute("DELETE FROM full_scan_summaries WHERE summary_id = ?", (summary_id,))
+        conn.execute("DELETE FROM scan_hashes WHERE summary_id = ?", (summary_id,))
         conn.commit()
     return cursor.rowcount > 0
 
@@ -187,5 +234,5 @@ def scan_exists(zip_hash, db_path=DB_NAME):
         return False
     with sqlite3.connect(db_path) as conn:
         ensure_db_initialized(conn)
-        row = conn.execute("SELECT 1 FROM full_scan_summaries WHERE zip_hash = ?", (zip_hash,)).fetchone()
+        row = conn.execute("SELECT 1 FROM scan_hashes WHERE file_hash = ?", (zip_hash,)).fetchone()
         return row is not None

--- a/src/scan_manager.py
+++ b/src/scan_manager.py
@@ -2,10 +2,12 @@ import os
 import shutil
 from datetime import datetime
 
-from db import delete_full_scan_by_id, get_full_scan_by_id, list_full_scans
+from db import delete_full_scan_by_id, get_full_scan_by_id, list_full_scans, update_full_scan
+from file_parser import get_input_file_path
 from permission_manager import get_yes_no
 from resume_generator import generate_resume, generate_contributor_portfolio
 from portfolio_generator import create_portfolios
+from services.scan_service import analyze_scan, merge_scans
 
 from print_utils import (
     print_repo_summary,
@@ -49,9 +51,10 @@ def scan_manager():
                 ("0", "Return to home screen"),
                 ("1", "View stored project analyses"),
                 ("2", "Generate Resume/Portfolio"),
-                ("3", "Delete stored scans"),
+                ("3", "Update an existing scan"),
+                ("4", "Delete stored scans"),
             ],
-            prompt="Choose an option (0–3): ",
+            prompt="Choose an option (0–4): ",
         )
 
         if choice == "1":
@@ -59,6 +62,8 @@ def scan_manager():
         elif choice == "2":
             generate_portfolio_menu()
         elif choice == "3":
+            update_scan_workflow()
+        elif choice == "4":
             delete_full_scan()
         elif choice == "0":
             break
@@ -150,6 +155,72 @@ def view_full_scan_details():
         except Exception as e:
             print(f"Error saving report: {e}")
 
+
+# --------------------------------------------------------
+# UPDATE SCAN
+# --------------------------------------------------------
+
+def update_scan_workflow():
+    _print_header("UPDATE EXISTING SCAN")
+    
+    # 1. Select existing scan
+    scans = list_full_scans()
+    if not scans:
+        print(_center_text("No existing scans found to update."))
+        return
+
+    print(_center_text("Select a scan to update:"))
+    _print_scan_list(scans)
+    
+    choice = input(_center_text(f"Choose (1-{len(scans)} or 0 to cancel): ")).strip()
+    if not choice.isdigit():
+        return
+    idx = int(choice)
+    if idx == 0 or idx > len(scans):
+        return
+    
+    target_scan_meta = scans[idx-1]
+    summary_id = target_scan_meta['summary_id']
+    
+    # Load full data
+    existing_record = get_full_scan_by_id(summary_id)
+    if not existing_record:
+        print(_center_text("Error loading scan data."))
+        return
+    
+    existing_data = existing_record['scan_data']
+
+    # 2. Select new file
+    print(_center_text("Select the new ZIP file to add:"))
+    result = get_input_file_path()
+    if not result:
+        return
+    file_list, zip_hash = result
+    
+    # Check if this file is already in the scan
+    current_hashes = set(existing_data.get("source_hashes", []))
+        
+    if zip_hash in current_hashes:
+        print(_center_text("This file has already been added to this scan."))
+        return
+
+    # 3. Analyze
+    print(_center_text("Analyzing new files..."))
+    analysis_mode = existing_record['analysis_mode']
+    # Use default advanced options (empty dict defaults to True in detailed_extraction)
+    new_results = analyze_scan(file_list, analysis_mode, {})
+    if new_results:
+        new_results["source_hashes"] = [zip_hash]
+    
+    # 4. Merge
+    merged_results = merge_scans(existing_data, new_results)
+    
+    # 5. Save
+    try:
+        update_full_scan(summary_id, merged_results)
+        print(_center_text("Portfolio updated successfully."))
+    except Exception as e:
+        print(_center_text(f"Error updating portfolio: {e}"))
 
 # --------------------------------------------------------
 # DELETE SCAN

--- a/src/services/scan_service.py
+++ b/src/services/scan_service.py
@@ -56,3 +56,53 @@ def run_scan(
     if results and persist:
         save_scan(results, analysis_mode, consent)
     return results
+
+
+def merge_scans(existing_data: Mapping[str, Any], new_data: Mapping[str, Any]) -> Mapping[str, Any]:
+    """
+    Merges new scan results into an existing scan dataset.
+    Used for incremental updates to a portfolio.
+    """
+    merged = dict(existing_data)  # Shallow copy
+
+    # 1. Merge Project Summaries (Append)
+    existing_projects = merged.get("project_summaries", [])
+    new_projects = new_data.get("project_summaries", [])
+    merged["project_summaries"] = existing_projects + new_projects
+
+    # 2. Merge Resume Summaries (Append)
+    merged["resume_summaries"] = merged.get("resume_summaries", []) + new_data.get("resume_summaries", [])
+
+    # 3. Merge Skills Chronological (Append)
+    merged["skills_chronological"] = merged.get("skills_chronological", []) + new_data.get("skills_chronological", [])
+
+    # 4. Merge Projects Chronological (Append)
+    merged["projects_chronological"] = merged.get("projects_chronological", []) + new_data.get("projects_chronological", [])
+
+    # 5. Merge Contributor Profiles (Union Skills)
+    existing_profiles = dict(merged.get("contributor_profiles", {}))
+    new_profiles = new_data.get("contributor_profiles", {})
+
+    for user, info in new_profiles.items():
+        if user in existing_profiles:
+            # Merge skills for existing user
+            old_skills = set(existing_profiles[user].get("skills", []))
+            new_skills = set(info.get("skills", []))
+            existing_profiles[user]["skills"] = list(old_skills.union(new_skills))
+            
+            # Merge projects list if present
+            old_projs = existing_profiles[user].get("projects", [])
+            new_projs = info.get("projects", [])
+            existing_profiles[user]["projects"] = old_projs + new_projs
+        else:
+            # New user
+            existing_profiles[user] = info
+    
+    merged["contributor_profiles"] = existing_profiles
+
+    # 6. Merge Source Hashes
+    existing_hashes = set(merged.get("source_hashes", []))
+    existing_hashes.update(new_data.get("source_hashes", []))
+    merged["source_hashes"] = list(existing_hashes)
+    
+    return merged

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -49,7 +49,8 @@ def test_save_full_scan_creates_tables_and_inserts_data(db_path):
         "resume_summaries": ["Bullet 1"],
         "skills_chronological": [],
         "projects_chronological": [],
-        "contributor_profiles": {"user1": {"skills": ["Python"]}}
+        "contributor_profiles": {"user1": {"skills": ["Python"]}},
+        "zip_hash": "abc123hash"
     }
 
     # Action
@@ -63,6 +64,7 @@ def test_save_full_scan_creates_tables_and_inserts_data(db_path):
     table_names = [t[0] for t in tables]
     assert "full_scan_summaries" in table_names
     assert "user_config" in table_names
+    assert "scan_hashes" in table_names
 
     # Verify data insertion
     rows = _fetch_all(
@@ -89,6 +91,14 @@ def test_save_full_scan_creates_tables_and_inserts_data(db_path):
     
     # Verify other fields
     assert data["contributor_profiles"]["user1"]["skills"] == ["Python"]
+
+    # Verify scan_hashes table population
+    hash_rows = _fetch_all(
+        db_path,
+        "SELECT file_hash FROM scan_hashes"
+    )
+    assert len(hash_rows) == 1
+    assert hash_rows[0][0] == "abc123hash"
 
 
 def test_list_full_scans_returns_lightweight_metadata(db_path):
@@ -199,3 +209,51 @@ def test_list_full_scans_ordering(db_path):
     # Should be ordered by timestamp DESC (newest first)
     assert scans[0]["analysis_mode"] == "advanced"
     assert scans[1]["analysis_mode"] == "basic"
+
+def test_update_full_scan(db_path):
+    """
+    SCENARIO: An existing scan is updated with new merged data.
+    EXPECTED: The JSON blob in the DB is updated, datetimes are serialized, and hashes table is updated.
+    """
+    # 1. Save initial scan
+    initial_data = {
+        "project_summaries": [{"project": "OldProject", "score": 10}],
+        "contributor_profiles": {"dev1": {"skills": ["Python"]}},
+        "timestamp": datetime.now().isoformat(),
+        "analysis_mode": "basic",
+        "user_consent": "Yes",
+        "source_hashes": ["hash1"]
+    }
+    db.save_full_scan(initial_data, "basic", True, db_path=db_path)
+    
+    # Get ID
+    scans = db.list_full_scans(db_path=db_path)
+    summary_id = scans[0]["summary_id"]
+
+    # 2. Prepare merged data (simulating what merge_scans would return)
+    # Include a datetime object to test serialization inside update_full_scan
+    updated_data = initial_data.copy()
+    updated_data["project_summaries"].append({
+        "project": "NewProject", 
+        "score": 20,
+        "first_modified": datetime(2024, 1, 1, 12, 0, 0),
+        "last_modified": datetime(2024, 2, 1, 12, 0, 0)
+    })
+    updated_data["source_hashes"] = ["hash1", "hash2"]
+
+    # 3. Call update
+    db.update_full_scan(summary_id, updated_data, db_path=db_path)
+
+    # 4. Verify
+    row = db.get_full_scan_by_id(summary_id, db_path=db_path)
+    scan_data = row["scan_data"]
+    
+    assert len(scan_data["project_summaries"]) == 2
+    assert scan_data["project_summaries"][1]["project"] == "NewProject"
+    # Verify datetime was serialized to string
+    assert scan_data["project_summaries"][1]["first_modified"] == "2024-01-01T12:00:00"
+    
+    # Verify hashes table update
+    hash_rows = _fetch_all(db_path, "SELECT file_hash FROM scan_hashes WHERE summary_id = ?", (summary_id,))
+    hashes = sorted([r[0] for r in hash_rows])
+    assert hashes == ["hash1", "hash2"]

--- a/tests/test_scan_service.py
+++ b/tests/test_scan_service.py
@@ -40,3 +40,131 @@ def test_run_scan_persists(monkeypatch):
 
     assert result == {"project_summaries": []}
     mock_save.assert_called_once_with({"project_summaries": []}, "basic", True)
+
+def test_merge_scans_logic():
+    """
+    SCENARIO: Merging an existing scan with a new scan.
+    EXPECTED: Lists are appended, contributor skills are unioned, new contributors are added.
+    """
+    # Existing data
+    existing = {
+        "project_summaries": [{"project": "A"}],
+        "resume_summaries": ["Worked on A"],
+        "skills_chronological": [{"skill": "Python"}],
+        "projects_chronological": [{"name": "A"}],
+        "contributor_profiles": {
+            "Alice": {"skills": ["Python"], "projects": [{"name": "A"}]}
+        },
+        "source_hashes": ["hashA"]
+    }
+
+    # New data
+    new_data = {
+        "project_summaries": [{"project": "B"}],
+        "resume_summaries": ["Worked on B"],
+        "skills_chronological": [{"skill": "Go"}],
+        "projects_chronological": [{"name": "B"}],
+        "contributor_profiles": {
+            "Alice": {"skills": ["Go"], "projects": [{"name": "B"}]},
+            "Bob": {"skills": ["Java"], "projects": [{"name": "B"}]}
+        },
+        "source_hashes": ["hashB"]
+    }
+
+    # Merge
+    merged = scan_service.merge_scans(existing, new_data)
+
+    # Assertions
+    assert len(merged["project_summaries"]) == 2
+    assert merged["project_summaries"][1]["project"] == "B"
+    assert len(merged["resume_summaries"]) == 2
+    assert len(merged["skills_chronological"]) == 2
+
+    # Alice should have Python AND Go (union of skills)
+    alice_skills = merged["contributor_profiles"]["Alice"]["skills"]
+    assert set(alice_skills) == {"Python", "Go"}
+    
+    # Bob should be added
+    assert "Bob" in merged["contributor_profiles"]
+    assert merged["contributor_profiles"]["Bob"]["skills"] == ["Java"]
+    
+    # Hashes
+    assert set(merged["source_hashes"]) == {"hashA", "hashB"}
+
+def test_merge_scans_empty_inputs():
+    """
+    SCENARIO: Both existing and new data are empty dictionaries.
+    EXPECTED: Returns a dictionary with initialized empty lists/dicts for standard keys.
+    """
+    existing = {}
+    new_data = {}
+    
+    merged = scan_service.merge_scans(existing, new_data)
+    
+    assert merged["project_summaries"] == []
+    assert merged["resume_summaries"] == []
+    assert merged["skills_chronological"] == []
+    assert merged["projects_chronological"] == []
+    assert merged["contributor_profiles"] == {}
+    assert merged["source_hashes"] == []
+
+def test_merge_scans_one_sided_new():
+    """
+    SCENARIO: Existing data is populated, new data is empty.
+    EXPECTED: Returns data identical to existing (plus initialized keys if missing).
+    """
+    existing = {
+        "project_summaries": [{"project": "A"}],
+        "contributor_profiles": {"Alice": {"skills": ["Python"]}}
+    }
+    new_data = {}
+    
+    merged = scan_service.merge_scans(existing, new_data)
+    
+    assert len(merged["project_summaries"]) == 1
+    assert merged["project_summaries"][0]["project"] == "A"
+    assert merged["contributor_profiles"]["Alice"]["skills"] == ["Python"]
+
+def test_merge_scans_one_sided_existing():
+    """
+    SCENARIO: Existing data is empty, new data is populated.
+    EXPECTED: Returns data identical to new data.
+    """
+    existing = {}
+    new_data = {
+        "project_summaries": [{"project": "B"}],
+        "contributor_profiles": {"Bob": {"skills": ["Java"]}}
+    }
+    
+    merged = scan_service.merge_scans(existing, new_data)
+    
+    assert len(merged["project_summaries"]) == 1
+    assert merged["project_summaries"][0]["project"] == "B"
+    assert merged["contributor_profiles"]["Bob"]["skills"] == ["Java"]
+
+def test_merge_scans_contributor_projects_concatenation():
+    """
+    SCENARIO: Merging contributor profiles where both have project lists.
+    EXPECTED: Project lists are concatenated for the same user.
+    """
+    existing = {"contributor_profiles": {"Alice": {"projects": [{"name": "A"}]}}}
+    new_data = {"contributor_profiles": {"Alice": {"projects": [{"name": "B"}]}}}
+    
+    merged = scan_service.merge_scans(existing, new_data)
+    
+    alice_projects = merged["contributor_profiles"]["Alice"]["projects"]
+    assert len(alice_projects) == 2
+    assert {p["name"] for p in alice_projects} == {"A", "B"}
+
+def test_merge_scans_duplicate_skills():
+    """
+    SCENARIO: Merging skills for a contributor where duplicates exist.
+    EXPECTED: Skills are unioned (no duplicates).
+    """
+    existing = {"contributor_profiles": {"Alice": {"skills": ["Python", "Java"]}}}
+    new_data = {"contributor_profiles": {"Alice": {"skills": ["Java", "C++"]}}}
+    
+    merged = scan_service.merge_scans(existing, new_data)
+    
+    skills = merged["contributor_profiles"]["Alice"]["skills"]
+    assert sorted(skills) == ["C++", "Java", "Python"]


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description
Implemented the ability to update existing portfolio scans with new project files. This allows users to build a comprehensive portfolio incrementally by scanning multiple ZIP files over time, rather than requiring all projects to be in a single ZIP archive.

It introduces a "Merge" logic layer that combines project summaries, skill timelines, and contributor profiles from different analysis sessions into a single persistent record.

1. User Interface: scan_manager.py
- New Menu Option: Added "Update an existing scan" to the Scan Manager menu.
- Workflow Implementation: Created update_scan_workflow, which:
- Lists existing portfolios for selection.
- Prompts for a new ZIP file.
- Deduplication Check: Prevents uploading the same file twice by comparing the new ZIP's hash against the portfolio's source_hashes.
- Triggers the analysis and merge process.
2. Service Layer scan_service.py
- New Function: merge_scans(existing_data, new_data)
- Projects: Appends new project summaries to the existing list.
- Skills: Merges chronological skill timelines.
- Contributors: Unions skill sets for existing contributors (e.g., if "Alice" used Python in Scan A and Java in Scan B, she now has both). Appends new projects to their history.
- History: Merges the source_hashes list to track all files contributing to the report.
3. Database Layer db.py
- Schema Normalization: Introduced a new table scan_hashes to map summary_id to file_hash (One-to-Many relationship). This replaces inefficient JSON parsing for deduplication.
- Update Logic: Added update_full_scan to overwrite the JSON blob of an existing record with the new merged data.
- Persistence: Updated save_full_scan and delete_full_scan_by_id to automatically manage entries in the scan_hashes table.


**Closes:** # (issue number)
#223 
---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] 📚 Documentation added/updated
- [X] ✅ Test added/updated
- [X] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

- [X] Unit Tests
These unit tests verify the Python logic responsible for combining two dictionaries of analysis results.

- test_merge_scans_logic: The core test case. It simulates merging "Project A" and "Project B".
    - Verification: Checks that the project count increases to 2, and that a contributor present in both projects has their skills unioned correctly.
- test_merge_scans_empty_inputs: Edge case.
    - Verification: Ensures the function returns a valid empty structure (lists/dicts) instead of crashing if input dictionaries are empty.
- test_merge_scans_one_sided_new & test_merge_scans_one_sided_existing: Edge cases.
     - Verification: Ensures that if one side of the merge is empty, the result matches the non-empty side exactly.
- test_merge_scans_contributor_projects_concatenation:
    - Verification: Checks that if "Alice" worked on Project A (existing) and Project B (new), her profile in the merged report lists both projects.
- test_merge_scans_duplicate_skills:
    - Verification: Checks that if "Python" appears in both scans for the same user, it is not listed twice in their skills list.
- test_update_full_scan:
    - Scenario: Saves a scan, creates a modified version of the data (simulating a merge), and calls update_full_scan.
    - Verification: Reloads the record from the DB and asserts that the JSON blob was updated, datetime objects were correctly serialized to strings, and the scan_hashes table was updated.
- test_save_full_scan_creates_tables_and_inserts_data:
    - Verification: Updated to explicitly check that the scan_hashes table is created and populated with the file hash upon saving a new scan.

- [X] Manual Testing

---

## ✓ Checklist

- [X] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [X] 💬 I have commented my code where needed
- [X] 📖 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [X] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] 🔗 Any dependent changes have been merged and published in downstream modules
- [X] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
