### PR TITLE
Split huge app.jsx into smaller components. Also reconfigured user flow

### DIFF
--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -1,56 +1,37 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import "./App.css";
+
+import Home from "./components/Home";
+import RunScan from "./components/RunScan";
+import ScanManager from "./components/ScanManager";
+import ResumeBuilder from "./components/ResumeBuilder";
+import PortfolioDashboard from "./components/PortfolioDashboard";
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL || "http://127.0.0.1:5000";
 
 function App() {
-  const [activeTab, setActiveTab] = useState("scan");
+  const [activeTab, setActiveTab] = useState("home");
   const [apiStatus, setApiStatus] = useState("checking");
   const [apiMessage, setApiMessage] = useState("");
+  const [showConsentModal, setShowConsentModal] = useState(false);
+  const [runScanKey, setRunScanKey] = useState(0);
 
   const [scans, setScans] = useState([]);
   const [scansLoading, setScansLoading] = useState(false);
   const [selectedScanId, setSelectedScanId] = useState("");
 
-  const [scanZipFile, setScanZipFile] = useState(null);
-  const [scanMode, setScanMode] = useState("basic");
-  const [scanConsent, setScanConsent] = useState(true);
-  const [scanPersist, setScanPersist] = useState(true);
-  const [scanAllowDuplicate, setScanAllowDuplicate] = useState(false);
-  const [scanIncremental, setScanIncremental] = useState(false);
-  const [scanIncrementalTarget, setScanIncrementalTarget] = useState("");
-  const [advancedOptions, setAdvancedOptions] = useState({
-    programming_scan: true,
-    framework_scan: true,
-    skills_gen: true,
-    resume_gen: true,
-  });
-  const [scanRunning, setScanRunning] = useState(false);
-  const [scanResult, setScanResult] = useState(null);
-  const [scanError, setScanError] = useState("");
+  const isNoise = useCallback((author) => {
+    if (!author) return true;
+    const lower = String(author).toLowerCase();
+    const noiseKeywords = ["bot", "dependabot", "snyk", "action", "jenkins", "github", "noreply"];
+    return noiseKeywords.some((kw) => lower.includes(kw));
+  }, []);
 
-  const [resumeTitle, setResumeTitle] = useState("Generated Resume");
-  const [resumeScanId, setResumeScanId] = useState("");
-  const [resumeProjects, setResumeProjects] = useState([]);
-  const [resumeSelectedProjectIds, setResumeSelectedProjectIds] = useState([]);
-  const [resumeLoadingProjects, setResumeLoadingProjects] = useState(false);
-  const [resumeGenerating, setResumeGenerating] = useState(false);
-  const [resumeArtifact, setResumeArtifact] = useState(null);
-  const [resumeError, setResumeError] = useState("");
-  const [resumeExporting, setResumeExporting] = useState(false);
-
-  const [portfolioTitle, setPortfolioTitle] = useState("Generated Portfolio");
-  const [portfolioScanId, setPortfolioScanId] = useState("");
-  const [portfolioProjects, setPortfolioProjects] = useState([]);
-  const [portfolioSelectedProjectIds, setPortfolioSelectedProjectIds] = useState([]);
-  const [portfolioLoadingProjects, setPortfolioLoadingProjects] = useState(false);
-  const [portfolioGenerating, setPortfolioGenerating] = useState(false);
-  const [portfolioArtifact, setPortfolioArtifact] = useState(null);
-  const [portfolioError, setPortfolioError] = useState("");
-  const [portfolioExporting, setPortfolioExporting] = useState(false);
-  const [portfolioViewMode, setPortfolioViewMode] = useState("private");
-  const [portfolioSearch, setPortfolioSearch] = useState("");
-  const [projectEdits, setProjectEdits] = useState({});
+  const formatTimestamp = useCallback((iso) => {
+    if (!iso) return "";
+    const d = new Date(iso);
+    return isNaN(d.getTime()) ? iso : d.toLocaleString("en-US", { month: "short", day: "numeric", year: "numeric", hour: "numeric", minute: "2-digit" });
+  }, []);
 
   const fetchJson = useCallback(async (path, options = {}) => {
     const response = await fetch(`${API_BASE}${path}`, options);
@@ -108,8 +89,6 @@ function App() {
       if (nextScans.length > 0) {
         const firstId = String(nextScans[0].summary_id);
         setSelectedScanId((prev) => prev || firstId);
-        setResumeScanId((prev) => prev || firstId);
-        setPortfolioScanId((prev) => prev || firstId);
       }
     } catch (error) {
       setApiStatus("offline");
@@ -151,6 +130,17 @@ function App() {
         if (!cancelled) {
           setApiStatus(data.status === "ok" ? "online" : "offline");
           setApiMessage(data.status === "ok" ? "API ready" : "API health check failed");
+
+          if (data.status === "ok") {
+            try {
+              const privacyData = await fetchJson("/privacy-consent");
+              if (!privacyData.privacy?.consent) {
+                setShowConsentModal(true);
+              }
+            } catch (e) {
+              console.error("Failed to check privacy consent", e);
+            }
+          }
         }
       } catch (error) {
         if (!cancelled) {
@@ -167,242 +157,54 @@ function App() {
     };
   }, [fetchJson, loadScans]);
 
-  useEffect(() => {
-    loadProjectsForScan(resumeScanId, {
-      setProjects: setResumeProjects,
-      setSelected: setResumeSelectedProjectIds,
-      setLoading: setResumeLoadingProjects,
-      setError: setResumeError,
-      limit: 0,
-    });
-  }, [resumeScanId, loadProjectsForScan]);
-
-  useEffect(() => {
-    loadProjectsForScan(portfolioScanId, {
-      setProjects: setPortfolioProjects,
-      setSelected: setPortfolioSelectedProjectIds,
-      setLoading: setPortfolioLoadingProjects,
-      setError: setPortfolioError,
-      limit: 3,
-    });
-    setProjectEdits({});
-  }, [portfolioScanId, loadProjectsForScan]);
-
-  const handleAdvancedOptionToggle = (key) => {
-    setAdvancedOptions((prev) => ({ ...prev, [key]: !prev[key] }));
-  };
-
-  const handleRunScan = async (event) => {
-    event.preventDefault();
-    setScanError("");
-    setScanResult(null);
-
-    if (!scanZipFile) {
-      setScanError("Select a .zip file before scanning.");
-      return;
-    }
-
-    setScanRunning(true);
+  const handleAcceptConsent = async () => {
     try {
-      const formData = new FormData();
-      formData.append("zip", scanZipFile);
-      formData.append("analysis_mode", scanMode);
-      formData.append("consent", String(scanConsent));
-      formData.append("persist", String(scanPersist));
-      formData.append("allow_duplicate", String(scanAllowDuplicate));
-      formData.append("incremental", String(scanIncremental));
-
-      if (scanMode === "advanced") {
-        formData.append("advanced_options", JSON.stringify(advancedOptions));
-      }
-      if (scanIncremental && scanIncrementalTarget) {
-        formData.append("existing_scan_id", scanIncrementalTarget);
-      }
-
-      const result = await fetchJson("/projects/upload", {
-        method: "POST",
-        body: formData,
-      });
-      setScanResult(result);
-      await loadScans();
-
-      if (result.summary_id) {
-        const sid = String(result.summary_id);
-        setSelectedScanId(sid);
-        setResumeScanId(sid);
-        setPortfolioScanId(sid);
-      }
-    } catch (error) {
-      setScanError(error.message);
-    } finally {
-      setScanRunning(false);
-    }
-  };
-
-  const toggleResumeProject = (projectId) => {
-    setResumeSelectedProjectIds((prev) =>
-      prev.includes(projectId) ? prev.filter((id) => id !== projectId) : [...prev, projectId]
-    );
-  };
-
-  const handleGenerateResume = async () => {
-    setResumeError("");
-    setResumeArtifact(null);
-
-    if (!resumeScanId) {
-      setResumeError("Select a scan first.");
-      return;
-    }
-    if (resumeSelectedProjectIds.length === 0) {
-      setResumeError("Select at least one project.");
-      return;
-    }
-
-    setResumeGenerating(true);
-    try {
-      const payload = {
-        scan_id: Number(resumeScanId),
-        title: resumeTitle.trim() || "Generated Resume",
-        selected_project_ids: resumeSelectedProjectIds,
-        project_order: resumeSelectedProjectIds,
-      };
-      const data = await fetchJson("/resume/generate", {
+      await fetchJson("/privacy-consent", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
+        body: JSON.stringify({ consent: true }),
       });
-      setResumeArtifact(data.resume);
+      setShowConsentModal(false);
     } catch (error) {
-      setResumeError(error.message);
-    } finally {
-      setResumeGenerating(false);
+      alert("Failed to save consent: " + error.message);
     }
   };
-
-  const handleExportResume = async () => {
-    if (!resumeArtifact?.resume_id) return;
-    setResumeExporting(true);
-    setResumeError("");
-    try {
-      await downloadArtifact(`/resume/${resumeArtifact.resume_id}/export`, "resume.docx");
-    } catch (error) {
-      setResumeError(error.message);
-    } finally {
-      setResumeExporting(false);
-    }
-  };
-
-  const togglePortfolioProject = (projectId) => {
-    setPortfolioError("");
-    setPortfolioSelectedProjectIds((prev) => {
-      if (prev.includes(projectId)) {
-        return prev.filter((id) => id !== projectId);
-      }
-      if (prev.length >= 3) {
-        setPortfolioError("Portfolio showcase is limited to top 3 projects.");
-        return prev;
-      }
-      return [...prev, projectId];
-    });
-  };
-
-  const updateProjectEdit = (projectId, key, value) => {
-    setProjectEdits((prev) => ({
-      ...prev,
-      [projectId]: {
-        ...prev[projectId],
-        [key]: value,
-      },
-    }));
-  };
-
-  const handleGeneratePortfolio = async () => {
-    setPortfolioError("");
-    setPortfolioArtifact(null);
-
-    if (!portfolioScanId) {
-      setPortfolioError("Select a scan first.");
-      return;
-    }
-    if (portfolioSelectedProjectIds.length === 0) {
-      setPortfolioError("Select 1 to 3 projects for the showcase.");
-      return;
-    }
-
-    setPortfolioGenerating(true);
-    try {
-      const generatePayload = {
-        scan_id: Number(portfolioScanId),
-        title: portfolioTitle.trim() || "Generated Portfolio",
-        selected_project_ids: portfolioSelectedProjectIds,
-        project_order: portfolioSelectedProjectIds,
-      };
-      const data = await fetchJson("/portfolio/generate", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(generatePayload),
-      });
-
-      let artifact = data.portfolio;
-      const editsToApply = {};
-      for (const projectId of portfolioSelectedProjectIds) {
-        if (projectEdits[projectId]) {
-          editsToApply[projectId] = projectEdits[projectId];
-        }
-      }
-
-      if (Object.keys(editsToApply).length > 0 && portfolioViewMode === "private") {
-        const edited = await fetchJson(`/portfolio/${artifact.portfolio_id}/edit`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ project_edits: editsToApply }),
-        });
-        artifact = edited.portfolio;
-      }
-      setPortfolioArtifact(artifact);
-    } catch (error) {
-      setPortfolioError(error.message);
-    } finally {
-      setPortfolioGenerating(false);
-    }
-  };
-
-  const handleExportPortfolio = async () => {
-    if (!portfolioArtifact?.portfolio_id) return;
-    setPortfolioExporting(true);
-    setPortfolioError("");
-    try {
-      await downloadArtifact(`/portfolio/${portfolioArtifact.portfolio_id}/export`, "portfolio.md");
-    } catch (error) {
-      setPortfolioError(error.message);
-    } finally {
-      setPortfolioExporting(false);
-    }
-  };
-
-  const visiblePortfolioItems = useMemo(() => {
-    const items = portfolioArtifact?.data?.items || [];
-    if (portfolioViewMode === "private" || !portfolioSearch.trim()) {
-      return items;
-    }
-    const needle = portfolioSearch.trim().toLowerCase();
-    return items.filter((item) => {
-      const bag = [
-        item.project_name,
-        item.text,
-        item.project_description,
-        item.role_description,
-        item.role,
-      ]
-        .filter(Boolean)
-        .join(" ")
-        .toLowerCase();
-      return bag.includes(needle);
-    });
-  }, [portfolioArtifact, portfolioViewMode, portfolioSearch]);
 
   return (
     <div className="app-shell">
+      {showConsentModal && (
+        <div style={{
+          position: "fixed", top: 0, left: 0, right: 0, bottom: 0,
+          backgroundColor: "rgba(0, 0, 0, 0.7)",
+          display: "flex", alignItems: "center", justifyContent: "center",
+          zIndex: 9999
+        }}>
+          <div className="panel" style={{ maxWidth: "500px", margin: "1rem" }}>
+            <h2>Privacy & Data Consent</h2>
+            <p>
+              Skill Scope requires your consent to process and analyze your project files.
+              By proceeding, you agree to allow the system to scan and store metadata about your code.
+            </p>
+            <div style={{ display: "flex", gap: "1rem", justifyContent: "flex-end", marginTop: "1.5rem" }}>
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={() => alert("You must provide consent to use the application features.")}
+              >
+                Decline
+              </button>
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={handleAcceptConsent}
+              >
+                I Consent
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       <header className="masthead">
         <div className="masthead-title-wrap">
           <p className="eyebrow">Milestone 3 Workbench</p>
@@ -422,438 +224,78 @@ function App() {
       <nav className="tab-row">
         <button
           type="button"
+          className={`tab ${activeTab === "home" ? "active" : ""}`}
+          onClick={() => setActiveTab("home")}
+        >
+          Home
+        </button>
+        <button
+          type="button"
           className={`tab ${activeTab === "scan" ? "active" : ""}`}
           onClick={() => setActiveTab("scan")}
         >
-          Scan Studio
+          Run a new scan
         </button>
         <button
           type="button"
-          className={`tab ${activeTab === "resume" ? "active" : ""}`}
-          onClick={() => setActiveTab("resume")}
+          className={`tab ${activeTab === "scan-manager" ? "active" : ""}`}
+          onClick={() => setActiveTab("scan-manager")}
         >
-          Resume Builder
-        </button>
-        <button
-          type="button"
-          className={`tab ${activeTab === "portfolio" ? "active" : ""}`}
-          onClick={() => setActiveTab("portfolio")}
-        >
-          Portfolio Dashboard
+          Scan Manager
         </button>
       </nav>
 
       <main className="content-grid">
-        {activeTab === "scan" && (
-          <section className="panel">
-            <h2>Run New Scan</h2>
-            <form className="grid-form" onSubmit={handleRunScan}>
-              <label className="field">
-                <span>Zip file</span>
-                <input
-                  type="file"
-                  accept=".zip"
-                  onChange={(event) => setScanZipFile(event.target.files?.[0] || null)}
-                />
-              </label>
-
-              <div className="field">
-                <span>Analysis mode</span>
-                <div className="inline-options">
-                  <label>
-                    <input
-                      type="radio"
-                      value="basic"
-                      checked={scanMode === "basic"}
-                      onChange={() => setScanMode("basic")}
-                    />
-                    Basic
-                  </label>
-                  <label>
-                    <input
-                      type="radio"
-                      value="advanced"
-                      checked={scanMode === "advanced"}
-                      onChange={() => setScanMode("advanced")}
-                    />
-                    Advanced
-                  </label>
-                </div>
-              </div>
-
-              {scanMode === "advanced" && (
-                <div className="field">
-                  <span>Advanced options</span>
-                  <div className="inline-options wrap">
-                    {Object.keys(advancedOptions).map((key) => (
-                      <label key={key}>
-                        <input
-                          type="checkbox"
-                          checked={advancedOptions[key]}
-                          onChange={() => handleAdvancedOptionToggle(key)}
-                        />
-                        {key}
-                      </label>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              <div className="field">
-                <span>Scan options</span>
-                <div className="inline-options wrap">
-                  <label>
-                    <input
-                      type="checkbox"
-                      checked={scanConsent}
-                      onChange={(event) => setScanConsent(event.target.checked)}
-                    />
-                    User consent
-                  </label>
-                  <label>
-                    <input
-                      type="checkbox"
-                      checked={scanPersist}
-                      onChange={(event) => setScanPersist(event.target.checked)}
-                    />
-                    Persist result
-                  </label>
-                  <label>
-                    <input
-                      type="checkbox"
-                      checked={scanAllowDuplicate}
-                      onChange={(event) => setScanAllowDuplicate(event.target.checked)}
-                    />
-                    Allow duplicate
-                  </label>
-                  <label>
-                    <input
-                      type="checkbox"
-                      checked={scanIncremental}
-                      onChange={(event) => setScanIncremental(event.target.checked)}
-                    />
-                    Incremental merge
-                  </label>
-                </div>
-              </div>
-
-              {scanIncremental && (
-                <label className="field">
-                  <span>Incremental target scan</span>
-                  <select
-                    value={scanIncrementalTarget}
-                    onChange={(event) => setScanIncrementalTarget(event.target.value)}
-                  >
-                    <option value="">Select scan</option>
-                    {scans.map((scan) => (
-                      <option key={scan.summary_id} value={scan.summary_id}>
-                        #{scan.summary_id} ({scan.analysis_mode}) {scan.timestamp}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-              )}
-
-              <button type="submit" className="btn btn-primary" disabled={scanRunning}>
-                {scanRunning ? "Scanning..." : "Run Scan"}
-              </button>
-            </form>
-
-            {scanError && <p className="error-text">{scanError}</p>}
-
-            {scanResult && (
-              <div className="result-card">
-                <h3>Scan Result</h3>
-                <p>
-                  Summary ID: <strong>{scanResult.summary_id ?? "not persisted"}</strong>
-                </p>
-                <p>
-                  Flags: persisted={String(scanResult.persisted)}, duplicate={String(scanResult.duplicate)},
-                  merged={String(scanResult.merged)}
-                </p>
-                <p>Projects detected: {(scanResult.projects || []).length}</p>
-                <div className="tag-wrap">
-                  {(scanResult.projects || []).map((project) => (
-                    <span className="tag" key={project.project_id}>
-                      {project.project_name}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            <div className="result-card">
-              <h3>Saved Scans</h3>
-              {scans.length === 0 ? (
-                <p>No saved scans yet.</p>
-              ) : (
-                <ul className="simple-list">
-                  {scans.map((scan) => (
-                    <li key={scan.summary_id}>
-                      <button
-                        type="button"
-                        className={`inline-link ${selectedScanId === String(scan.summary_id) ? "active" : ""}`}
-                        onClick={() => {
-                          const sid = String(scan.summary_id);
-                          setSelectedScanId(sid);
-                          setResumeScanId(sid);
-                          setPortfolioScanId(sid);
-                        }}
-                      >
-                        #{scan.summary_id} | {scan.analysis_mode} | {scan.timestamp}
-                      </button>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
-          </section>
-        )}
-
-        {activeTab === "resume" && (
-          <section className="panel">
-            <h2>Resume Builder</h2>
-            <div className="grid-form">
-              <label className="field">
-                <span>Source scan</span>
-                <select value={resumeScanId} onChange={(event) => setResumeScanId(event.target.value)}>
-                  <option value="">Select scan</option>
-                  {scans.map((scan) => (
-                    <option key={scan.summary_id} value={scan.summary_id}>
-                      #{scan.summary_id} ({scan.analysis_mode}) {scan.timestamp}
-                    </option>
-                  ))}
-                </select>
-              </label>
-
-              <label className="field">
-                <span>Resume title</span>
-                <input value={resumeTitle} onChange={(event) => setResumeTitle(event.target.value)} />
-              </label>
-
-              <div className="field">
-                <span>Projects for this resume</span>
-                {resumeLoadingProjects ? (
-                  <p>Loading projects...</p>
-                ) : resumeProjects.length === 0 ? (
-                  <p>No projects for this scan.</p>
-                ) : (
-                  <ul className="project-list">
-                    {resumeProjects.map((project) => (
-                      <li key={project.project_id}>
-                        <label>
-                          <input
-                            type="checkbox"
-                            checked={resumeSelectedProjectIds.includes(project.project_id)}
-                            onChange={() => toggleResumeProject(project.project_id)}
-                          />
-                          <span>
-                            {project.project_name}
-                            <small>
-                              score: {project.score ?? "n/a"} | type: {project.project_type ?? "n/a"}
-                            </small>
-                          </span>
-                        </label>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </div>
-
-              <button type="button" className="btn btn-primary" onClick={handleGenerateResume} disabled={resumeGenerating}>
-                {resumeGenerating ? "Generating..." : "Generate Resume"}
-              </button>
-
-              {resumeError && <p className="error-text">{resumeError}</p>}
-
-              {resumeArtifact && (
-                <div className="result-card">
-                  <h3>Resume Artifact #{resumeArtifact.resume_id}</h3>
-                  <p>Selected projects: {(resumeArtifact.data?.selected_project_ids || []).length}</p>
-                  <ul className="simple-list">
-                    {(resumeArtifact.data?.items || []).map((item) => (
-                      <li key={item.project_id}>
-                        <strong>{item.project_name}</strong>
-                        <p>{item.text}</p>
-                      </li>
-                    ))}
-                  </ul>
-                  <button
-                    type="button"
-                    className="btn btn-secondary"
-                    onClick={handleExportResume}
-                    disabled={resumeExporting}
-                  >
-                    {resumeExporting ? "Exporting..." : "Export DOCX"}
-                  </button>
-                </div>
-              )}
-            </div>
-          </section>
-        )}
-
-        {activeTab === "portfolio" && (
-          <section className="panel">
-            <h2>Portfolio Dashboard</h2>
-            <div className="grid-form">
-              <div className="field">
-                <span>Dashboard mode</span>
-                <div className="inline-options">
-                  <label>
-                    <input
-                      type="radio"
-                      checked={portfolioViewMode === "private"}
-                      onChange={() => setPortfolioViewMode("private")}
-                    />
-                    Private (customize)
-                  </label>
-                  <label>
-                    <input
-                      type="radio"
-                      checked={portfolioViewMode === "public"}
-                      onChange={() => setPortfolioViewMode("public")}
-                    />
-                    Public (search/filter)
-                  </label>
-                </div>
-              </div>
-
-              <label className="field">
-                <span>Source scan</span>
-                <select value={portfolioScanId} onChange={(event) => setPortfolioScanId(event.target.value)}>
-                  <option value="">Select scan</option>
-                  {scans.map((scan) => (
-                    <option key={scan.summary_id} value={scan.summary_id}>
-                      #{scan.summary_id} ({scan.analysis_mode}) {scan.timestamp}
-                    </option>
-                  ))}
-                </select>
-              </label>
-
-              <label className="field">
-                <span>Portfolio title</span>
-                <input value={portfolioTitle} onChange={(event) => setPortfolioTitle(event.target.value)} />
-              </label>
-
-              <div className="field">
-                <span>Top 3 showcase projects</span>
-                {portfolioLoadingProjects ? (
-                  <p>Loading projects...</p>
-                ) : portfolioProjects.length === 0 ? (
-                  <p>No projects for this scan.</p>
-                ) : (
-                  <ul className="project-list">
-                    {portfolioProjects.map((project) => (
-                      <li key={project.project_id}>
-                        <label>
-                          <input
-                            type="checkbox"
-                            checked={portfolioSelectedProjectIds.includes(project.project_id)}
-                            onChange={() => togglePortfolioProject(project.project_id)}
-                          />
-                          <span>
-                            {project.project_name}
-                            <small>score: {project.score ?? "n/a"}</small>
-                          </span>
-                        </label>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </div>
-
-              {portfolioViewMode === "private" &&
-                portfolioSelectedProjectIds.map((projectId) => {
-                  const project = portfolioProjects.find((p) => p.project_id === projectId);
-                  const current = projectEdits[projectId] || {};
-                  return (
-                    <div className="result-card" key={projectId}>
-                      <h3>{project?.project_name || projectId}</h3>
-                      <label className="field">
-                        <span>Role</span>
-                        <input
-                          value={current.role || ""}
-                          onChange={(event) => updateProjectEdit(projectId, "role", event.target.value)}
-                          placeholder="Lead Developer, Analyst, etc."
-                        />
-                      </label>
-                      <label className="field">
-                        <span>Evidence of success</span>
-                        <input
-                          value={current.evidence_of_success || ""}
-                          onChange={(event) =>
-                            updateProjectEdit(projectId, "evidence_of_success", event.target.value)
-                          }
-                          placeholder="Outcome or measurable impact"
-                        />
-                      </label>
-                      <label className="field">
-                        <span>Portfolio showcase text</span>
-                        <textarea
-                          value={current.portfolio_showcase_text || ""}
-                          onChange={(event) =>
-                            updateProjectEdit(projectId, "portfolio_showcase_text", event.target.value)
-                          }
-                          rows={3}
-                          placeholder="Narrative to show in the portfolio card"
-                        />
-                      </label>
-                    </div>
-                  );
-                })}
-
-              {portfolioViewMode === "public" && (
-                <label className="field">
-                  <span>Search portfolio content</span>
-                  <input
-                    value={portfolioSearch}
-                    onChange={(event) => setPortfolioSearch(event.target.value)}
-                    placeholder="Filter generated portfolio cards"
-                  />
-                </label>
-              )}
-
-              <button
-                type="button"
-                className="btn btn-primary"
-                onClick={handleGeneratePortfolio}
-                disabled={portfolioGenerating}
-              >
-                {portfolioGenerating ? "Generating..." : "Generate Portfolio"}
-              </button>
-
-              {portfolioError && <p className="error-text">{portfolioError}</p>}
-
-              {portfolioArtifact && (
-                <div className="result-card">
-                  <h3>Portfolio Artifact #{portfolioArtifact.portfolio_id}</h3>
-                  <p>Showcase items: {visiblePortfolioItems.length}</p>
-                  <div className="portfolio-cards">
-                    {visiblePortfolioItems.map((item) => (
-                      <article className="portfolio-card" key={item.project_id}>
-                        <h4>{item.project_name}</h4>
-                        <p>{item.project_description || item.text}</p>
-                        {item.role_description && <p className="muted">Role: {item.role_description}</p>}
-                        {item.tech_stack?.length > 0 && (
-                          <p className="muted">Tech: {item.tech_stack.join(", ")}</p>
-                        )}
-                        {item.contribution_display && <p className="muted">{item.contribution_display}</p>}
-                      </article>
-                    ))}
-                  </div>
-                  <button
-                    type="button"
-                    className="btn btn-secondary"
-                    onClick={handleExportPortfolio}
-                    disabled={portfolioExporting}
-                  >
-                    {portfolioExporting ? "Exporting..." : "Export Markdown"}
-                  </button>
-                </div>
-              )}
-            </div>
-          </section>
-        )}
+        <div style={{ display: activeTab === "home" ? "block" : "none" }}>
+          <Home setActiveTab={setActiveTab} onStartNewScan={() => {
+            setRunScanKey((prev) => prev + 1);
+            setActiveTab("scan");
+          }} />
+        </div>
+        <div style={{ display: activeTab === "scan" ? "block" : "none" }}>
+          <RunScan
+            key={runScanKey}
+            fetchJson={fetchJson}
+            loadScans={loadScans}
+            setSelectedScanId={setSelectedScanId}
+            isNoise={isNoise}
+            setActiveTab={setActiveTab}
+          />
+        </div>
+        <div style={{ display: activeTab === "scan-manager" ? "block" : "none" }}>
+          <ScanManager
+            isActive={activeTab === "scan-manager"}
+            scans={scans}
+            selectedScanId={selectedScanId}
+            setSelectedScanId={setSelectedScanId}
+            fetchJson={fetchJson}
+            isNoise={isNoise}
+            setActiveTab={setActiveTab}
+            formatTimestamp={formatTimestamp}
+          />
+        </div>
+        <div style={{ display: activeTab === "resume" ? "block" : "none" }}>
+          <ResumeBuilder
+            scans={scans}
+            selectedScanId={selectedScanId}
+            fetchJson={fetchJson}
+            downloadArtifact={downloadArtifact}
+            loadProjectsForScan={loadProjectsForScan}
+            setActiveTab={setActiveTab}
+            formatTimestamp={formatTimestamp}
+          />
+        </div>
+        <div style={{ display: activeTab === "portfolio" ? "block" : "none" }}>
+          <PortfolioDashboard
+            scans={scans}
+            selectedScanId={selectedScanId}
+            fetchJson={fetchJson}
+            downloadArtifact={downloadArtifact}
+            loadProjectsForScan={loadProjectsForScan}
+            setActiveTab={setActiveTab}
+            formatTimestamp={formatTimestamp}
+          />
+        </div>
       </main>
     </div>
   );

--- a/src/ui/components/Home.jsx
+++ b/src/ui/components/Home.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+export default function Home({ setActiveTab, onStartNewScan }) {
+  return (
+    <section className="panel">
+      <div style={{ textAlign: "center", padding: "3rem 1rem" }}>
+        <h2>Welcome to Skill Scope!</h2>
+        <p style={{ maxWidth: "600px", margin: "1rem auto", lineHeight: "1.6" }}>
+          Skill Scope scans a project folder to summarize languages, frameworks, timelines, and contributions, then saves the results for later review.
+        </p>
+        <div style={{ display: "flex", gap: "1rem", justifyContent: "center", marginTop: "2rem" }}>
+          <button
+            type="button"
+            className="btn btn-primary"
+            style={{ padding: "0.75rem 1.5rem", fontSize: "1.1rem" }}
+            onClick={onStartNewScan || (() => setActiveTab("scan"))}
+          >
+            Run a New Scan
+          </button>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            style={{ padding: "0.75rem 1.5rem", fontSize: "1.1rem" }}
+            onClick={() => setActiveTab("scan-manager")}
+          >
+            Scan Manager
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/ui/components/PortfolioDashboard.jsx
+++ b/src/ui/components/PortfolioDashboard.jsx
@@ -1,0 +1,178 @@
+import React, { useState, useEffect, useMemo } from "react";
+
+export default function PortfolioDashboard({ scans, selectedScanId, fetchJson, downloadArtifact, loadProjectsForScan, setActiveTab, formatTimestamp }) {
+  const [portfolioTitle, setPortfolioTitle] = useState("Generated Portfolio");
+  const [portfolioScanId, setPortfolioScanId] = useState("");
+  const [portfolioProjects, setPortfolioProjects] = useState([]);
+  const [portfolioSelectedProjectIds, setPortfolioSelectedProjectIds] = useState([]);
+  const [portfolioLoadingProjects, setPortfolioLoadingProjects] = useState(false);
+  const [portfolioGenerating, setPortfolioGenerating] = useState(false);
+  const [portfolioArtifact, setPortfolioArtifact] = useState(null);
+  const [portfolioError, setPortfolioError] = useState("");
+  const [portfolioExporting, setPortfolioExporting] = useState(false);
+  const [portfolioViewMode, setPortfolioViewMode] = useState("private");
+  const [portfolioSearch, setPortfolioSearch] = useState("");
+  const [projectEdits, setProjectEdits] = useState({});
+
+  useEffect(() => {
+    if (selectedScanId) {
+      setPortfolioScanId(selectedScanId);
+    }
+  }, [selectedScanId]);
+
+  useEffect(() => {
+    loadProjectsForScan(portfolioScanId, {
+      setProjects: setPortfolioProjects,
+      setSelected: setPortfolioSelectedProjectIds,
+      setLoading: setPortfolioLoadingProjects,
+      setError: setPortfolioError,
+      limit: 3,
+    });
+    setProjectEdits({});
+  }, [portfolioScanId, loadProjectsForScan]);
+
+  const togglePortfolioProject = (projectId) => {
+    setPortfolioError("");
+    setPortfolioSelectedProjectIds((prev) => {
+      if (prev.includes(projectId)) return prev.filter((id) => id !== projectId);
+      if (prev.length >= 3) {
+        setPortfolioError("Portfolio showcase is limited to top 3 projects.");
+        return prev;
+      }
+      return [...prev, projectId];
+    });
+  };
+
+  const updateProjectEdit = (projectId, key, value) => {
+    setProjectEdits((prev) => ({ ...prev, [projectId]: { ...prev[projectId], [key]: value } }));
+  };
+
+  const handleGeneratePortfolio = async () => {
+    setPortfolioError("");
+    setPortfolioArtifact(null);
+    if (!portfolioScanId) return setPortfolioError("Select a scan first.");
+    if (portfolioSelectedProjectIds.length === 0) return setPortfolioError("Select 1 to 3 projects for the showcase.");
+
+    setPortfolioGenerating(true);
+    try {
+      const generatePayload = {
+        scan_id: Number(portfolioScanId),
+        title: portfolioTitle.trim() || "Generated Portfolio",
+        selected_project_ids: portfolioSelectedProjectIds,
+        project_order: portfolioSelectedProjectIds,
+      };
+      const data = await fetchJson("/portfolio/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(generatePayload),
+      });
+
+      let artifact = data.portfolio;
+      const editsToApply = {};
+      for (const projectId of portfolioSelectedProjectIds) {
+        if (projectEdits[projectId]) editsToApply[projectId] = projectEdits[projectId];
+      }
+
+      if (Object.keys(editsToApply).length > 0 && portfolioViewMode === "private") {
+        const edited = await fetchJson(`/portfolio/${artifact.portfolio_id}/edit`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ project_edits: editsToApply }),
+        });
+        artifact = edited.portfolio;
+      }
+      setPortfolioArtifact(artifact);
+    } catch (error) {
+      setPortfolioError(error.message);
+    } finally {
+      setPortfolioGenerating(false);
+    }
+  };
+
+  const handleExportPortfolio = async () => {
+    if (!portfolioArtifact?.portfolio_id) return;
+    setPortfolioExporting(true);
+    setPortfolioError("");
+    try {
+      await downloadArtifact(`/portfolio/${portfolioArtifact.portfolio_id}/export`, "portfolio.md");
+    } catch (error) {
+      setPortfolioError(error.message);
+    } finally {
+      setPortfolioExporting(false);
+    }
+  };
+
+  const visiblePortfolioItems = useMemo(() => {
+    const items = portfolioArtifact?.data?.items || [];
+    if (portfolioViewMode === "private" || !portfolioSearch.trim()) return items;
+    const needle = portfolioSearch.trim().toLowerCase();
+    return items.filter((item) => {
+      const bag = [item.project_name, item.text, item.project_description, item.role_description, item.role].filter(Boolean).join(" ").toLowerCase();
+      return bag.includes(needle);
+    });
+  }, [portfolioArtifact, portfolioViewMode, portfolioSearch]);
+
+  return (
+    <section className="panel">
+      <div style={{ display: "flex", alignItems: "center", gap: "1rem", marginBottom: "1rem" }}>
+        <button
+          type="button"
+          className="btn btn-secondary"
+          style={{ padding: "0.25rem 0.5rem" }}
+          onClick={() => setActiveTab("scan-manager")}
+        >
+          &larr; Back
+        </button>
+        <h2 style={{ margin: 0 }}>Portfolio Dashboard</h2>
+      </div>
+
+      <div className="grid-form">
+        <div className="field">
+          <span>Dashboard mode</span>
+          <div className="inline-options">
+            <label><input type="radio" checked={portfolioViewMode === "private"} onChange={() => setPortfolioViewMode("private")} /> Private (customize)</label>
+            <label><input type="radio" checked={portfolioViewMode === "public"} onChange={() => setPortfolioViewMode("public")} /> Public (search/filter)</label>
+          </div>
+        </div>
+        <label className="field">
+          <span>Source scan</span>
+          <select value={portfolioScanId} onChange={(e) => setPortfolioScanId(e.target.value)}>
+            <option value="">Select scan</option>
+            {scans.map((scan) => (<option key={scan.summary_id} value={scan.summary_id}>Scan {scan.summary_id} - {formatTimestamp(scan.timestamp)} ({scan.analysis_mode})</option>))}
+          </select>
+        </label>
+        <label className="field"><span>Portfolio title</span><input value={portfolioTitle} onChange={(e) => setPortfolioTitle(e.target.value)} /></label>
+        <div className="field">
+          <span>Top 3 showcase projects</span>
+          {portfolioLoadingProjects ? (<p>Loading projects...</p>) : portfolioProjects.length === 0 ? (<p>No projects for this scan.</p>) : (
+            <ul className="project-list">{portfolioProjects.map((project) => (<li key={project.project_id}><label><input type="checkbox" checked={portfolioSelectedProjectIds.includes(project.project_id)} onChange={() => togglePortfolioProject(project.project_id)} /><span>{project.project_name} <small>score: {project.score ?? "n/a"}</small></span></label></li>))}</ul>
+          )}
+        </div>
+
+        {portfolioViewMode === "private" && portfolioSelectedProjectIds.map((projectId) => {
+          const project = portfolioProjects.find((p) => p.project_id === projectId);
+          const current = projectEdits[projectId] || {};
+          return (
+            <div className="result-card" key={projectId}>
+              <h3>{project?.project_name || projectId}</h3>
+              <label className="field"><span>Role</span><input value={current.role || ""} onChange={(e) => updateProjectEdit(projectId, "role", e.target.value)} placeholder="Lead Developer, Analyst, etc." /></label>
+              <label className="field"><span>Evidence of success</span><input value={current.evidence_of_success || ""} onChange={(e) => updateProjectEdit(projectId, "evidence_of_success", e.target.value)} placeholder="Outcome or measurable impact" /></label>
+              <label className="field"><span>Portfolio showcase text</span><textarea value={current.portfolio_showcase_text || ""} onChange={(e) => updateProjectEdit(projectId, "portfolio_showcase_text", e.target.value)} rows={3} placeholder="Narrative to show in the portfolio card" /></label>
+            </div>
+          );
+        })}
+        {portfolioViewMode === "public" && (<label className="field"><span>Search portfolio content</span><input value={portfolioSearch} onChange={(e) => setPortfolioSearch(e.target.value)} placeholder="Filter generated portfolio cards" /></label>)}
+        <button type="button" className="btn btn-primary" onClick={handleGeneratePortfolio} disabled={portfolioGenerating}>{portfolioGenerating ? "Generating..." : "Generate Portfolio"}</button>
+        {portfolioError && <p className="error-text">{portfolioError}</p>}
+        {portfolioArtifact && (
+          <div className="result-card">
+            <h3>Portfolio Artifact #{portfolioArtifact.portfolio_id}</h3>
+            <p>Showcase items: {visiblePortfolioItems.length}</p>
+            <div className="portfolio-cards">{visiblePortfolioItems.map((item) => (<article className="portfolio-card" key={item.project_id}><h4>{item.project_name}</h4><p>{item.project_description || item.text}</p>{item.role_description && <p className="muted">Role: {item.role_description}</p>}{item.tech_stack?.length > 0 && (<p className="muted">Tech: {Array.isArray(item.tech_stack) ? item.tech_stack.join(", ") : item.tech_stack}</p>)}{item.contribution_display && <p className="muted">{item.contribution_display}</p>}</article>))}</div>
+            <button type="button" className="btn btn-secondary" onClick={handleExportPortfolio} disabled={portfolioExporting}>{portfolioExporting ? "Exporting..." : "Export Markdown"}</button>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/ui/components/ResumeBuilder.jsx
+++ b/src/ui/components/ResumeBuilder.jsx
@@ -1,0 +1,126 @@
+import React, { useState, useEffect } from "react";
+
+export default function ResumeBuilder({ scans, selectedScanId, fetchJson, downloadArtifact, loadProjectsForScan, setActiveTab, formatTimestamp }) {
+  const [resumeTitle, setResumeTitle] = useState("Generated Resume");
+  const [resumeScanId, setResumeScanId] = useState("");
+  const [resumeProjects, setResumeProjects] = useState([]);
+  const [resumeSelectedProjectIds, setResumeSelectedProjectIds] = useState([]);
+  const [resumeLoadingProjects, setResumeLoadingProjects] = useState(false);
+  const [resumeGenerating, setResumeGenerating] = useState(false);
+  const [resumeArtifact, setResumeArtifact] = useState(null);
+  const [resumeError, setResumeError] = useState("");
+  const [resumeExporting, setResumeExporting] = useState(false);
+
+  useEffect(() => {
+    if (selectedScanId) {
+      setResumeScanId(selectedScanId);
+    }
+  }, [selectedScanId]);
+
+  useEffect(() => {
+    loadProjectsForScan(resumeScanId, {
+      setProjects: setResumeProjects,
+      setSelected: setResumeSelectedProjectIds,
+      setLoading: setResumeLoadingProjects,
+      setError: setResumeError,
+      limit: 0,
+    });
+  }, [resumeScanId, loadProjectsForScan]);
+
+  const toggleResumeProject = (projectId) => {
+    setResumeSelectedProjectIds((prev) =>
+      prev.includes(projectId) ? prev.filter((id) => id !== projectId) : [...prev, projectId]
+    );
+  };
+
+  const handleGenerateResume = async () => {
+    setResumeError("");
+    setResumeArtifact(null);
+    if (!resumeScanId) return setResumeError("Select a scan first.");
+    if (resumeSelectedProjectIds.length === 0) return setResumeError("Select at least one project.");
+
+    setResumeGenerating(true);
+    try {
+      const payload = {
+        scan_id: Number(resumeScanId),
+        title: resumeTitle.trim() || "Generated Resume",
+        selected_project_ids: resumeSelectedProjectIds,
+        project_order: resumeSelectedProjectIds,
+      };
+      const data = await fetchJson("/resume/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      setResumeArtifact(data.resume);
+    } catch (error) {
+      setResumeError(error.message);
+    } finally {
+      setResumeGenerating(false);
+    }
+  };
+
+  const handleExportResume = async () => {
+    if (!resumeArtifact?.resume_id) return;
+    setResumeExporting(true);
+    setResumeError("");
+    try {
+      await downloadArtifact(`/resume/${resumeArtifact.resume_id}/export`, "resume.docx");
+    } catch (error) {
+      setResumeError(error.message);
+    } finally {
+      setResumeExporting(false);
+    }
+  };
+
+  return (
+    <section className="panel">
+      <div style={{ display: "flex", alignItems: "center", gap: "1rem", marginBottom: "1rem" }}>
+        <button
+          type="button"
+          className="btn btn-secondary"
+          style={{ padding: "0.25rem 0.5rem" }}
+          onClick={() => setActiveTab("scan-manager")}
+        >
+          &larr; Back
+        </button>
+        <h2 style={{ margin: 0 }}>Resume Builder</h2>
+      </div>
+
+      <div className="grid-form">
+        <label className="field">
+          <span>Source scan</span>
+          <select value={resumeScanId} onChange={(e) => setResumeScanId(e.target.value)}>
+            <option value="">Select scan</option>
+            {scans.map((scan) => (
+              <option key={scan.summary_id} value={scan.summary_id}>Scan {scan.summary_id} - {formatTimestamp(scan.timestamp)} ({scan.analysis_mode})</option>
+            ))}
+          </select>
+        </label>
+        <label className="field"><span>Resume title</span><input value={resumeTitle} onChange={(e) => setResumeTitle(e.target.value)} /></label>
+        <div className="field">
+          <span>Projects for this resume</span>
+          {resumeLoadingProjects ? (<p>Loading projects...</p>) : resumeProjects.length === 0 ? (<p>No projects for this scan.</p>) : (
+            <ul className="project-list">
+              {resumeProjects.map((project) => (
+                <li key={project.project_id}>
+                  <label><input type="checkbox" checked={resumeSelectedProjectIds.includes(project.project_id)} onChange={() => toggleResumeProject(project.project_id)} /><span>{project.project_name} <small>score: {project.score ?? "n/a"} | type: {project.project_type ?? "n/a"}</small></span></label>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <button type="button" className="btn btn-primary" onClick={handleGenerateResume} disabled={resumeGenerating}>{resumeGenerating ? "Generating..." : "Generate Resume"}</button>
+        {resumeError && <p className="error-text">{resumeError}</p>}
+        {resumeArtifact && (
+          <div className="result-card">
+            <h3>Resume Artifact #{resumeArtifact.resume_id}</h3>
+            <p>Selected projects: {(resumeArtifact.data?.selected_project_ids || []).length}</p>
+            <ul className="simple-list">{(resumeArtifact.data?.items || []).map((item) => (<li key={item.project_id}><strong>{item.project_name}</strong><p>{item.text}</p></li>))}</ul>
+            <button type="button" className="btn btn-secondary" onClick={handleExportResume} disabled={resumeExporting}>{resumeExporting ? "Exporting..." : "Export DOCX"}</button>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/ui/components/RunScan.jsx
+++ b/src/ui/components/RunScan.jsx
@@ -1,0 +1,203 @@
+import React, { useState } from "react";
+
+export default function RunScan({ fetchJson, loadScans, setSelectedScanId, isNoise, setActiveTab }) {
+  const [scanZipFile, setScanZipFile] = useState(null);
+  const [scanMode, setScanMode] = useState("basic");
+  const [advancedOptions, setAdvancedOptions] = useState({
+    programming_scan: true,
+    framework_scan: true,
+    skills_gen: true,
+    resume_gen: true,
+  });
+  const [scanRunning, setScanRunning] = useState(false);
+  const [scanResult, setScanResult] = useState(null);
+  const [scanError, setScanError] = useState("");
+
+  const handleAdvancedOptionToggle = (key) => {
+    setAdvancedOptions((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const handleRunScan = async (event) => {
+    event.preventDefault();
+    setScanError("");
+    setScanResult(null);
+
+    if (!scanZipFile) {
+      setScanError("Select a .zip file before scanning.");
+      return;
+    }
+
+    setScanRunning(true);
+    try {
+      const buffer = await scanZipFile.arrayBuffer();
+      const hashBuffer = await crypto.subtle.digest("SHA-256", buffer);
+      const hashArray = Array.from(new Uint8Array(hashBuffer));
+      const fileHash = hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+
+      const checkData = await fetchJson(`/scans/check?file_hash=${encodeURIComponent(fileHash)}`);
+      let allowDuplicate = "false";
+
+      if (checkData.exists) {
+        const proceed = window.confirm("Warning: This project has already been scanned.\n\nDo you want to scan it again?");
+        if (!proceed) {
+          setScanRunning(false);
+          return;
+        }
+        allowDuplicate = "true";
+      }
+
+      const formData = new FormData();
+      formData.append("zip", scanZipFile);
+      formData.append("analysis_mode", scanMode);
+      formData.append("consent", "true");
+      formData.append("persist", "true");
+      formData.append("allow_duplicate", allowDuplicate);
+      formData.append("incremental", "false");
+
+      if (scanMode === "advanced") {
+        formData.append("advanced_options", JSON.stringify(advancedOptions));
+      }
+
+      const result = await fetchJson("/projects/upload", {
+        method: "POST",
+        body: formData,
+      });
+      setScanResult(result);
+      await loadScans();
+
+      if (result.summary_id) {
+        setSelectedScanId(String(result.summary_id));
+      }
+    } catch (error) {
+      setScanError(error.message);
+    } finally {
+      setScanRunning(false);
+    }
+  };
+
+  return (
+    <section className="panel">
+      <h2>Run New Scan</h2>
+      <form className="grid-form" onSubmit={handleRunScan}>
+        <label className="field">
+          <span>Zip file</span>
+          <input
+            type="file"
+            accept=".zip"
+            onChange={(event) => setScanZipFile(event.target.files?.[0] || null)}
+          />
+        </label>
+
+        <div className="field">
+          <span>Analysis mode</span>
+          <div className="inline-options">
+            <label><input type="radio" value="basic" checked={scanMode === "basic"} onChange={() => setScanMode("basic")} /> Basic</label>
+            <label><input type="radio" value="advanced" checked={scanMode === "advanced"} onChange={() => setScanMode("advanced")} /> Advanced</label>
+          </div>
+        </div>
+
+        {scanMode === "advanced" && (
+          <div className="field">
+            <span>Advanced options</span>
+            <div className="inline-options wrap">
+              {Object.keys(advancedOptions).map((key) => (
+                <label key={key}>
+                  <input type="checkbox" checked={advancedOptions[key]} onChange={() => handleAdvancedOptionToggle(key)} />{" "}
+                  {key.split("_")
+                    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+                    .join(" ")}
+                </label>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <button 
+          type="submit" 
+          className="btn btn-primary" 
+          disabled={scanRunning}
+          style={scanRunning ? { display: "inline-flex", alignItems: "center", justifyContent: "center", gap: "0.5rem" } : {}}
+        >
+          {scanRunning ? (
+            <>
+              <svg width="1.2em" height="1.2em" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none">
+                <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" style={{ opacity: 0.25 }} />
+                <path fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z">
+                  <animateTransform attributeName="transform" type="rotate" from="0 12 12" to="360 12 12" dur="1s" repeatCount="indefinite" />
+                </path>
+              </svg>
+              Scanning...
+            </>
+          ) : (
+            "Run Scan"
+          )}
+        </button>
+      </form>
+
+      {scanError && <p className="error-text">{scanError}</p>}
+
+      {scanResult && (
+        <div className="result-card">
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: "1rem" }}>
+            <div>
+              <h3 style={{ marginTop: 0 }}>Scan Complete</h3>
+              <p style={{ margin: 0 }}>
+                <strong>Scan ID:</strong> #{scanResult.summary_id ?? "not persisted"}{" "}
+                {scanResult.duplicate && <span className="tag" style={{ backgroundColor: "#fde8e8", color: "#9b1c1c", borderColor: "#fbd5d5" }}>Duplicate</span>}
+                {scanResult.merged && <span className="tag" style={{ backgroundColor: "#e1effe", color: "#1e429f", borderColor: "#c3ddfd" }}>Merged</span>}
+              </p>
+            </div>
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={() => setActiveTab("scan-manager")}
+            >
+              View in Scan Manager
+            </button>
+          </div>
+
+          {(() => {
+            const profiles = scanResult.results?.contributor_profiles || {};
+            const validContributors = Object.keys(profiles).filter(c => !isNoise(c));
+            if (validContributors.length === 0) return null;
+            return (
+              <div style={{ marginBottom: "1rem" }}>
+                <strong>Contributors Detected:</strong>
+                <div className="tag-wrap" style={{ marginTop: "0.5rem" }}>
+                  {validContributors.map((contributor) => (
+                    <span className="tag" key={contributor} style={{ backgroundColor: "#f3f4f6", borderColor: "#e5e7eb" }}>{contributor}</span>
+                  ))}
+                </div>
+              </div>
+            );
+          })()}
+
+          <strong>Projects Detected: {(scanResult.projects || []).length}</strong>
+          <ul className="project-list" style={{ marginTop: "0.5rem" }}>
+            {(scanResult.projects || []).map((project, idx) => (
+              <li key={project.project_id || idx}>
+                <div style={{ display: "flex", justifyContent: "space-between" }}>
+                  <strong>{project.project_name || project.project || project.name || `Project ${idx + 1}`}</strong>
+                  {project.project_type && <span className="muted" style={{ margin: 0, fontSize: "0.85rem" }}>{project.project_type}</span>}
+                </div>
+                <div className="muted" style={{ marginBottom: "0.5rem" }}>
+                  Languages: {[].concat(project.languages || []).join(", ") || "None"} <br />
+                  Frameworks: {[].concat(project.frameworks || []).join(", ") || "None"}
+                </div>
+                {(() => {
+                  const skills = Array.isArray(project.skills) ? project.skills : (typeof project.skills === "string" ? project.skills.split(",") : []);
+                  return skills.length > 0 ? (
+                    <div className="tag-wrap">
+                      {skills.slice(0, 8).map((skill, i) => (<span className="tag" key={i}>{String(skill).trim()}</span>))}
+                      {skills.length > 8 && (<span className="tag">+{skills.length - 8} more</span>)}
+                    </div>
+                  ) : null;
+                })()}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/ui/components/ScanManager.jsx
+++ b/src/ui/components/ScanManager.jsx
@@ -1,0 +1,129 @@
+import React, { useState, useEffect, useCallback } from "react";
+
+export default function ScanManager({ isActive, scans, selectedScanId, setSelectedScanId, fetchJson, isNoise, setActiveTab, formatTimestamp }) {
+  const [scanManagerDetails, setScanManagerDetails] = useState(null);
+  const [scanManagerLoading, setScanManagerLoading] = useState(false);
+
+  const loadScanDetails = useCallback(async (scanId) => {
+    if (!scanId) return;
+    setScanManagerLoading(true);
+    setScanManagerDetails(null);
+    try {
+      const data = await fetchJson(`/scans/${scanId}`);
+      setScanManagerDetails(data.scan);
+    } catch (err) {
+      console.error("Failed to load scan details", err);
+    } finally {
+      setScanManagerLoading(false);
+    }
+  }, [fetchJson]);
+
+  useEffect(() => {
+    if (isActive && selectedScanId) {
+      loadScanDetails(selectedScanId);
+    }
+  }, [isActive, selectedScanId, loadScanDetails]);
+
+  return (
+    <section className="panel">
+      <h2>Scan Manager</h2>
+      <div style={{ display: "flex", gap: "1.5rem", alignItems: "flex-start", flexWrap: "wrap", marginTop: "1rem" }}>
+        <div className="result-card" style={{ flex: "1 1 300px" }}>
+          <h3 style={{ marginTop: 0 }}>Saved Scans</h3>
+          {scans.length === 0 ? (
+            <p>No saved scans yet.</p>
+          ) : (
+            <ul className="simple-list">
+              {scans.map((scan) => (
+                <li key={scan.summary_id}>
+                  <button
+                    type="button"
+                    className={`inline-link ${selectedScanId === String(scan.summary_id) ? "active" : ""}`}
+                    onClick={() => {
+                      setSelectedScanId(String(scan.summary_id));
+                    }}
+                  >
+                  Scan {scan.summary_id} - {formatTimestamp(scan.timestamp)} ({scan.analysis_mode})
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <div style={{ flex: "2 1 500px" }}>
+          {scanManagerLoading ? (
+            <div className="result-card"><p>Loading details...</p></div>
+          ) : scanManagerDetails ? (
+            <div className="result-card">
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: "1rem" }}>
+                <div>
+                  <h3 style={{ marginTop: 0 }}>Scan Details #{scanManagerDetails.summary_id}</h3>
+                  <p style={{ margin: 0 }}>
+                    <strong>Mode:</strong> {scanManagerDetails.analysis_mode} <br/>
+                  <strong>Date:</strong> {formatTimestamp(scanManagerDetails.timestamp)}
+                  </p>
+                </div>
+                <div style={{ display: "flex", gap: "0.5rem" }}>
+                  <button
+                    type="button"
+                    className="btn btn-primary"
+                    onClick={() => setActiveTab("resume")}
+                  >
+                    Build Resume
+                  </button>
+                  <button
+                    type="button"
+                    className="btn btn-secondary"
+                    onClick={() => setActiveTab("portfolio")}
+                  >
+                    Build Portfolio
+                  </button>
+                </div>
+              </div>
+              
+              {(() => {
+                const profiles = scanManagerDetails.scan_data?.contributor_profiles || {};
+                const validContributors = Object.keys(profiles).filter(c => !isNoise(c));
+                if (validContributors.length === 0) return null;
+                return (
+                  <div style={{ marginBottom: "1rem" }}>
+                    <strong>Contributors Detected:</strong>
+                    <div className="tag-wrap" style={{ marginTop: "0.5rem" }}>
+                      {validContributors.map((contributor) => (
+                        <span className="tag" key={contributor} style={{ backgroundColor: "#f3f4f6", borderColor: "#e5e7eb" }}>{contributor}</span>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })()}
+
+              <strong>Projects Detected: {(scanManagerDetails.scan_data?.project_summaries || []).length}</strong>
+              <ul className="project-list" style={{ marginTop: "0.5rem" }}>
+                {(scanManagerDetails.scan_data?.project_summaries || []).map((project, idx) => (
+                  <li key={idx}>
+                    <div style={{ display: "flex", justifyContent: "space-between" }}>
+                      <strong>{project.project || project.name || `Project ${idx + 1}`}</strong>
+                      {project.project_type && <span className="muted" style={{ margin: 0, fontSize: "0.85rem" }}>{project.project_type}</span>}
+                    </div>
+                    <div className="muted" style={{ marginBottom: "0.5rem" }}>
+                      Languages: {[].concat(project.languages || []).join(", ") || "None"} <br />
+                      Frameworks: {[].concat(project.frameworks || []).join(", ") || "None"}
+                    </div>
+                    {(() => {
+                      const skills = Array.isArray(project.skills) ? project.skills : (typeof project.skills === "string" ? project.skills.split(",") : []);
+                      return skills.length > 0 ? (
+                        <div className="tag-wrap">{skills.slice(0, 8).map((skill, i) => (<span className="tag" key={i}>{String(skill).trim()}</span>))}{skills.length > 8 && (<span className="tag">+{skills.length - 8} more</span>)}</div>
+                      ) : null;
+                    })()}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : (
+            <div className="result-card"><p>Select a scan to view details.</p></div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

> Please include a summary of the change and which issue is fixed.  
> Include relevant motivation and context.  
> List any dependencies that are required for this change.
### Architecture & Refactoring

- Component Modularity: Split the massive App.jsx into 5 distinct, maintainable components located in src/ui/components/:
- Home.jsx
- RunScan.jsx
- ScanManager.jsx
- ResumeBuilder.jsx
- PortfolioDashboard.jsx
- Utilities: Centralized helper functions like isNoise (for filtering bot contributors) and formatTimestamp inside [App.jsx] and passed them down as props.

### UI & UX Improvements

- New Home Screen: Added a welcome screen that serves as the default landing page, offering clear paths to "Run a New Scan" or open the "Scan Manager".
- Streamlined Navigation: Removed "Resume Builder" and "Portfolio Dashboard" from the top-level navigation bar. Users now access these tools organically by selecting a scan in the Scan Manager and clicking "Build Resume" or "Build Portfolio".
- Back Navigation: Added "<- Back" buttons to the Artifact Builders to quickly return to the Scan Manager.
- Form Resetting: Navigating to "Run a New Scan" from the Home screen now forces a complete state reset of the upload form.
- Visual Feedback: Added a clean SVG loading spinner to the "Run Scan" button to indicate background processing.
- Readable Timestamps: Converted raw ISO strings into localized, human-readable dates (e.g., Scan 12 - Mar 12, 2026, 10:12 AM).

### Feature Additions
- Privacy Consent Modal: The app now intercepts the user on startup, pinging the /privacy-consent API and forcing a full-screen consent overlay if they haven't agreed to data processing yet.
- Pre-Upload Duplicate Checking: Replicated the api_main.py logic by hashing the selected zip file locally (crypto.subtle) and checking /scans/check. It now warns the user with a native confirm dialog before wasting bandwidth uploading a duplicate file.
- Rich Scan Results: Completely overhauled the "Scan Complete" and "Scan Details" panels to display a rich breakdown of detected contributors, projects, languages, frameworks, and skills, replacing the old raw ID/flag outputs.
- Noise Filtering: Implemented frontend filtering to automatically hide bot accounts (dependabot, snyk, noreply, etc.) from the contributor lists, keeping the UI clean without destroying the raw data in the database.

### Bug Fixes

- Crash Prevention: Fixed a critical bug where legacy or manually edited skills or tech_stack data stored as comma-separated strings instead of arrays would cause fatal React crashes (white screens). Added safe array conversions before mapping.
- Cleaned up Advanced Options: Removed unnecessary backend parameter checkboxes (persist, consent) from the UI and dynamically formatted the advanced option keys to be human-readable (e.g., programming_scan -> "Programming Scan").


**Closes:** # (issue number)

---

## 🔧 Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] 📚 Documentation added/updated
- [X] ✅ Test added/updated
- [X] ♻️ Refactoring
- [X] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

- [X] Unit Tests
- All unit and api tests pass
- [X] Manual testing
- Extensive manual testing of UI was performed

---

## ✓ Checklist

- [X] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [X] 💬 I have commented my code where needed
- [X] 📖 I have made corresponding changes to the documentation
- [X] ⚠️ My changes generate no new warnings
- [X] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [X] 🔗 Any dependent changes have been merged and published in downstream modules
- [X] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
